### PR TITLE
ヘッダーに投稿一覧ページへのリンクを追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
             <li class='nav-item dropdown'>
               <% if logged_in? %>
                 <%= link_to t('.logout'), logout_path, data: { turbo_method: :delete } %>
-                <%= link_to t('.user_index'), posts_path %>
+                <%= link_to t('.posts'), posts_path %>
               <% else %>
                 <%= link_to t('.login'), login_path %>
                 <%= link_to t('.new_user'), new_user_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,6 +34,7 @@
             <li class='nav-item dropdown'>
               <% if logged_in? %>
                 <%= link_to t('.logout'), logout_path, data: { turbo_method: :delete } %>
+                <%= link_to t('.user_index'), posts_path %>
               <% else %>
                 <%= link_to t('.login'), login_path %>
                 <%= link_to t('.new_user'), new_user_path %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,3 +22,4 @@ ja:
       login: ログイン
       logout: ログアウト
       new_user: 新規登録
+      user_index: ユーザー一覧

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,4 +22,4 @@ ja:
       login: ログイン
       logout: ログアウト
       new_user: 新規登録
-      user_index: ユーザー一覧
+      posts: 投稿一覧


### PR DESCRIPTION
### 概要
ヘッダーに投稿一覧ページへのリンクが表示されるように修正した
これによりログイン中はどの画面からでも投稿一覧ページに遷移できるようになる

---
### 修正内容
 **ヘッダーに投稿一覧ページへのリンクを作成**
  - ファイル:  'app/views/layouts/application.html.erb'
  - 内容:  ログイン中のみヘッダーに投稿一覧ページへのリンクが表示される仕組みを記述
  ```
　　　　<% if logged_in? %>
                <%= link_to t('.logout'), logout_path, data: { turbo_method: :delete } %>
                <%= link_to t('.posts'), posts_path %>
              <% else %>
                <%= link_to t('.login'), login_path %>
                <%= link_to t('.new_user'), new_user_path %>
              <% end %>
  ``` 

---
### 確認方法
- '/login' にアクセスし、メールアドレスとパスワードを入力しログイン
- ログイン後、ヘッダーにユーザー投稿一覧リンクが表示されることを確認

---