### PR TITLE
コメント一覧表示機能の実装

### DIFF
--- a/app/assets/stylesheets/posts_show.css
+++ b/app/assets/stylesheets/posts_show.css
@@ -1,0 +1,4 @@
+.comment {
+ padding: 10px;
+ border-bottom: 1px solid #ddd;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,6 +12,18 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = Post.find(params[:post_id])
+    @comment = Comment.find(params[:id])
+    if @comment.delete
+      flash[:notice] = t('flash.comments.destroy.success')
+      redirect_to post_path(@post)
+    else
+      flash.now[:alert] = @comment.error.full_messages
+      render "post/show"
+    end
+  end
+
   def comment_params
     params.require(:comment).permit(:content, :user_id)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,7 +22,7 @@ class PostsController < ApplicationController
   def show
     @post = Post.includes(:user).find(params[:id])
     @comment = @post.comments.build
-    @comments = @post.comments
+    @comments = @post.comments.includes(:user)
   end
 
   def edit

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -63,7 +63,7 @@
             <% end %>
         </div>
       <% else %>
-        <strong>現在コメントはありません</strong>
+        <strong><%= t('.comment_nil') %></strong>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -37,6 +37,34 @@
     </div>
   </div>
 </div>
-
+<div class="container mt-2">  
+  <div class="mx-auto" style="max-width: 500px;">
+    <div class="card-body">
+      <% if @comments.exists? %>
+        <h3><%= t('.comment')%></h3>
+        <div class="card-body">
+            <% @comments.each do |comment| %>
+              <div class="comment">
+                <div>
+                  <p><strong><%= comment.user.name %></strong></p>
+                  <p><%= comment.content %></p>
+                </div>
+                <% if comment.user.id == current_user.id %>
+                  <div class="row justify-content-end ">
+                    <div class="col-auto">
+                      <%= link_to t('.edit'), class:"btn btn-primary" %>
+                    </div>
+                    <div class="col-auto">
+                      <%= link_to t('.delete'), post_comment_path(@post, comment), data:{ turbo_method: :delete } %>
+                    </div>
+                  </div>
+                <% end%>
+              </div>
+            <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
 
    

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -62,6 +62,8 @@
               </div>
             <% end %>
         </div>
+      <% else %>
+        <strong>現在コメントはありません</strong>
       <% end %>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -56,3 +56,4 @@ ja:
       delete: 削除
       comment_form: コメント投稿
       submit: 送信
+      comment_nil: 現在コメントがありません

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,7 +18,13 @@ ja:
         success: 投稿を更新しました
     comments:
       create:
-        success: 投稿に成功しました
+        success: コメントの投稿に成功しました
+      destroy:
+        success: コメントの削除に成功しました
+  helpers:
+    label:
+      email: メールアドレス
+      password: パスワード
   user_sessions:
     new:
       title: ログイン


### PR DESCRIPTION
###　概要
投稿に紐づくコメントを一覧表示する機能を実装
またコメント削除機能も追加しました

---
### 修正内容
**1. 投稿一覧表示**
  - コントローラ
    - 'app/controllers/posts_controller.rb' の 'show' アクションを修正
    - @commentsにコメントに紐づくユーザー情報を含めるように修正
      - viewで各コメントのユーザー名を表示するため
  -  ビュー
    - 対象の投稿に紐づくコメントを一覧表示
      - コメントがない場合は"現在コメントがありません"と表示

**2. 投稿削除**
- コントローラ
  -  'app/controllers/posts_controller.rb' に'destroy'アクションを追加
    - 成功時と失敗時に対応するフラッシュメッセージを表示
- ビュー
  - 'app/views/posts/show.html.erb'に削除ボタンを作成
    - 現在ログインしているユーザーのidとコメントを投稿したユーザーのidが一致する場合のみ削除ボタンを表示
 
---
### 確認方法
1. /post/:id にアクセスし、コメント一覧が表示されているかを確認(コメントがない場合は"現在コメントがありません"と表示)
2. 自分が投稿したコメントには削除リンクが表示されていることを確認
3. 削除リンクを選択すると投稿が削除され、フラッシュメッセージが表示されることを確認