### PR TITLE
いいねの重複ができないように修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -9,8 +9,8 @@ class BookmarksController < ApplicationController
       flash[:notice] = "いいねしました!"
       redirect_to post_path(post)
     else
-      flash.now[:alert] = bookmark.errors.full_messages
-      render "post/show", status: :unprocessable_entity
+      flash[:alert] = "すでにいいねされています！"
+      redirect_to post_path(post)
     end
   end
 

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -4,6 +4,8 @@ class Bookmark < ApplicationRecord
 
   after_create :send_bookmark_notification
 
+  validates :user_id, uniqueness: { scope: :post_id }
+
   def send_bookmark_notification
     NotificationMailer.new_bookmark_notification(post.user, post).deliver_later
   end


### PR DESCRIPTION
### 概要
同じ投稿に重複していいねができないようにbookmarkモデルにバリデーションルールを追加

---
### 修正内容
1. 'app/models/bookmark.rb' に以下のバリデーションルールを追加
```
  validates :user_id, uniqueness: { scope: :post_id }
```

2. その他
  - いいねに失敗した際の処理を以下のように修正
  ```
      else
      flash[:alert] = "すでにいいねされています！"
      redirect_to post_path(post)
    end
  ```
---
### 確認方法
1. /posts/:id にアクセスし、いいねボタンをクリックする
2. もう一度同じ投稿に対していいねボタンをクリックした際に"すでにいいねされています！"と表示されることを確認