### PR TITLE
お気に入り一覧から投稿の詳細に飛ぶ仕組みを修正

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -3,7 +3,7 @@
   <% @bookmarks.each do |bookmark| %>
     <div class="card mb-3">
       <div class="card-body">
-        <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark) %></h4><br>
+        <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id) %></h4><br>
         <p class="card-text"><%= simple_format(bookmark.post.description) %> </p>
         <p class="card-text text-end "><%= t('.user')%>:<%= bookmark.user.name %>
         <p class="card-text text-end "><%= t('.post_day')%>:<%= bookmark.created_at.strftime('%Y年%m月%d日') %></p>


### PR DESCRIPTION
### 概要
お気に入り一覧に表示されている投稿リンクから詳細ページ遷移を行う仕組みにエラーが発生していたため
正しく遷移できるように修正しました

---
### 修正内容
- リンクから送信するリクエストに含まれるidをbookmark.idからpost.idに修正
```
<div class="card-body">
        <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id) %></h4><br>
```

---
### 確認内容
/bookmarks にアクセスし、投稿のリンクをクリックすると、詳細ページに遷移することを確認
