### PR TITLE
いいね解除機能の追加

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -14,6 +14,17 @@ class BookmarksController < ApplicationController
     end
   end
 
+  def destroy
+    bookmark = Bookmark.find(params[:id])
+    if bookmark.delete
+      flash[:notice] = "いいねを解除しました"
+      redirect_to bookmarks_path
+    else
+      flash[:alert] = bookmark.errors.full_messages
+      redirect_to bookmarks_path
+    end
+  end
+
   def bookmark_params
     params.require(:bookmark).permit(:user_id, :post_id)
   end

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,8 +5,15 @@
       <div class="card-body">
         <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id) %></h4><br>
         <p class="card-text"><%= simple_format(bookmark.post.description) %> </p>
-        <p class="card-text text-end "><%= t('.user')%>:<%= bookmark.user.name %>
-        <p class="card-text text-end "><%= t('.post_day')%>:<%= bookmark.created_at.strftime('%Y年%m月%d日') %></p>
+          <p class="card-text text-end "><%= t('.user')%>:<%= bookmark.user.name %></p>
+          <div class="d-flex justify-content-between">
+            <%= form_with url: bookmark_path(bookmark), method: :delete, class: "d-inline" do %>
+              <button type="submit" class="btn btn-outline-danger">
+                <i class="fa-solid fa-heart"></i> いいね解除
+              </button>
+            <% end %>
+            <p class="card-text"><%= t('.post_day')%>:<%= bookmark.created_at.strftime('%Y年%m月%d日') %></p>
+          </div>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
### 概要
お気に入り一覧に各投稿ごとのいいね解除ボタンを実装しました

---
### 修正内容
1. コントローラ
  - 'app/contorollers/bookmark_controller.rb' に'destroy' アクションを追加
    - bookmarkの削除処理を実行

2. ビュー
  - 'app/views/bookmarks/index.html.erb' にいいね解除ボタンを追加

---
### 確認内容
/bookmarks にアクセスし、いいね解除ボタンをクリックすると一覧から対象の投稿が削除され、"いいねが解除されました"というフラッシュメッセージが表示される
