### PR TITLE
検索結果が0件の場合でもタイトルが表示されるように修正

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,6 +1,6 @@
+<h3 class="text-center"><%= t('.title')%></h3>
 <%= render 'search_form', q: @search, url: bookmarks_path %>
 <% if @bookmarks.present?%>
-  <h3 class="text-center"><%= t('.title')%></h3>
   <% @bookmarks.each do |bookmark| %>
     <div class="card mb-3">
       <div class="card-body">


### PR DESCRIPTION
### 概要
現在お気に入り一覧において、検索結果が0件の場合ページタイトルが表示されない状態であるため、
0件の場合でもページタイトルが表示されるように修正しました

---
### 修正内容
'app/views/bookmarks/index.html.erb' においてページタイトルを条件分岐の外に出した

---
### 確認内容
/bookmarks にアクセスし、検索結果が0件の場合でもページタイトルが表示されることを確認
