### PR TITLE
ページネーションを共通化できるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,12 @@
 class PostsController < ApplicationController
   def index
-    page = (params[:page].to_i > 0) ? params[:page].to_i : 1
+    @page = (params[:page].to_i > 0) ? params[:page].to_i : 1
     @search = Post.ransack(params[:q])
-    @posts = @search.result(distinct: true).includes(:user).offset((page - 1)*(Post.pagination_per_page)).limit(Post.pagination_per_page)
+    @posts = @search.result(distinct: true).includes(:user).offset((@page - 1)*(Post.pagination_per_page)).limit(Post.pagination_per_page)
     @total_posts = @search.result(distinct: true).includes(:user).count
-    @previous_page = page > 1 ? page - 1 : nil
-    @next_page = @total_posts > page * (Post.pagination_per_page) ? page + 1 : nil
-    @page = page
+    @previous_page = @page > 1 ? @page - 1 : nil
+    @next_page = @total_posts > @page * (Post.pagination_per_page) ? @page + 1 : nil
+    @items = @posts
   end
 
   def new
@@ -26,6 +26,7 @@ class PostsController < ApplicationController
   end
 
   def show
+    binding.pry
     @post = Post.includes(:user).find(params[:id])
     @comment = @post.comments.build
     @comments = @post.comments.includes(:user)

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,8 +1,0 @@
-<div class="card mb-3">
-  <div class="card-body">
-    <h4 class="card-title"><%= link_to post.title, post_path(post) %></h4><br>
-    <p class="card-text"><%= simple_format(post.description) %> </p>
-    <p class="card-text text-end "><%= t('.user')%>:<%= post.user.name %>
-    <p class="card-text text-end "><%= t('.post_day')%>:<%= post.created_at.strftime('%Y年%m月%d日') %></p>
-  </div>
-</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,15 +6,15 @@
 </div>
 <% if @posts.exists? %>
   <turbo-frame>
-    <%= render @posts %>
+    <%= render 'shared/pagination', posts: @items %>
   </turbo-frame>
+  <div class=" page container d-flex justify-content-center">
+  <%= link_to 'Previous', posts_path(page: @previous_page), data: { turbo: false }, class: "mx-2" if @previous_page %>
+  <%= @page %>
+  <%= link_to 'Next', posts_path(page: @next_page), data: { turbo: false }, class: "mx-2" if @next_page %>
+</div>
 <% else %>
   <div class="container d-flex justify-content-center align-items-center" style="height: 100vh;">
     <strong>検索結果はありません</strong>
   <div>
 <% end %>
-<div class=" page container d-flex justify-content-center">
-  <%= link_to 'Previous', posts_path(page: @previous_page), data: { turbo: false }, class: "mx-2" if @previous_page %>
-  <%= @page %>
-  <%= link_to 'Next', posts_path(page: @next_page), data: { turbo: false }, class: "mx-2" if @next_page %>
-</div>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,0 +1,10 @@
+<% posts.each do |post| %>
+  <div class="card mb-3">
+    <div class="card-body">
+      <h4 class="card-title"><%= link_to post.title, post_path(post) %></h4><br>
+      <p class="card-text"><%= simple_format(post.description) %> </p>
+      <p class="card-text text-end "><%= t('.user')%>:<%= post.user.name %>
+      <p class="card-text text-end "><%= t('.post_day')%>:<%= post.created_at.strftime('%Y年%m月%d日') %></p>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
### 概要
投稿一覧ページとお気に入り一覧ページのページごとに切り替わる内容を共通化できるように
'app/views/posts/_post.html.erb'ファイルを修正しました

---
### 修正内容
**1. ファイルの名称と階層を変更**
  - app/views/shared/_pagination.html.erb

**2. renderにキーワード変数を渡す仕組みに変更**

**3. その他**
'app/contorollers/posts_controller.rb' のpageをインスタンス変数@pageに変更

---
### 確認方法
1. 投稿の総件数に基づいて'Next' 'Previous'が表示されることを確認
  例) 最初のページでは'Next'のみ表示され、最終ページでは'Previous'のみが表示される
2. 投稿内容が正しくページングされているかを確認
    1ページに10件の投稿が表示されている 
3. ページ下部に現在のページ数が表示されていることを確認