### PR TITLE
投稿詳細ページに遷移できないエラーの修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,8 +1,8 @@
 class BookmarksController < ApplicationController
   def index
-    @search = Post.ransack(params[:q])  # Ransackを使って検索クエリを処理
+    @search = current_user.bookmarks.ransack(params[:q])
     @page = (params[:page].to_i > 0) ? params[:page].to_i : 1
-    @bookmarks = current_user.bookmarks.ransack(params[:q]).result(distinct: true).includes(:post)
+    @bookmarks = @search.result(distinct: true).includes(:post)
     @bookmarks = @bookmarks.offset((@page - 1) * Post.pagination_per_page).limit(Post.pagination_per_page)
     @total_posts = @bookmarks.count
     @previous_page = @page > 1 ? @page - 1 : nil

--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,10 +1,10 @@
 <div class="card mb-3">
   <div class="card-body">
-    <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id) %></h4><br>
+    <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id), data: { turbo: false } %></h4><br>
     <p class="card-text"><%= simple_format(bookmark.post.description) %> </p>
       <p class="card-text text-end "><%= t('.user')%>:<%= bookmark.user.name %></p>
       <div class="d-flex justify-content-between">
-        <%= form_with url: bookmark_path(bookmark), method: :delete, class: "d-inline" do %>
+        <%= form_with url: bookmark_path(bookmark), method: :delete, class: "d-inline", data: { turbo: false } do %>
           <button type="submit" class="btn btn-outline-danger">
             <i class="fa-solid fa-heart"></i> いいね解除
           </button>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -2,7 +2,7 @@
 <%= render 'search_form', q: @search, url: bookmarks_path %>
 <% if @bookmarks.present?%>
   <turbo-frame>
-    <%= render @bookmarks %>
+    <%= render partial: 'bookmark', collection: @bookmarks %>
   </turbo-frame>
   <div class=" page container d-flex justify-content-center">
   <%= link_to 'Previous', bookmarks_path(page: @previous_page), data: { turbo: false }, class: "mx-2" if @previous_page %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card mb-3">
   <div class="card-body">
-    <h4 class="card-title"><%= link_to post.title, post_path(post) %></h4><br>
+    <h4 class="card-title"><%= link_to post.title, post_path(post), data: { turbo: false } %></h4><br>
     <p class="card-text"><%= simple_format(post.description) %> </p>
     <p class="card-text text-end "><%= t('.user')%>:<%= post.user.name %>
     <p class="card-text text-end "><%= t('.post_day')%>:<%= post.created_at.strftime('%Y年%m月%d日') %></p>


### PR DESCRIPTION
### 概要
以下のエラーを修正するためにturbo-frame内のリンクとフォームにおけるturboを無効化しました

turbo-frama内にある投稿の詳細情報へ遷移するリンクをクリックすると、postsコントローラのshowアクションにデータが送信されるが、非同期更新されるのは<turbo-frame>のタグ内(postsコントローラのindexアクション)であり、データが空であるため何も表示されないというエラー

### 修正内容
1. '_post.html.erb' におけるリンクのturboを無効化しました

2.  '_bookmark.html.erb' におけるリンクとフォームのturboを無効化しました

3.  その他
  -  bookmarksコントローラのindexアクションにおける@searchの修正
  - bookmarks.index.html.erbのrenderの記述を以下に変更
    -  <%= render partial: 'bookmark', collection: @bookmarks %>

### 確認方法
1. /posts にアクセスし、タイトルリンクをクリックした際に対象の投稿の詳細ページに遷移することを確認
2. /bookmarks にアクセスし、タイトルリンクをクリックした際に対象の投稿の詳細ページに遷移することを確認
