### PR TITLE
turbo-frameを用いたページ遷移においてURLを含めた部分更新ができるように修正

### DIFF
--- a/app/views/bookmarks/_bookmark.html.erb
+++ b/app/views/bookmarks/_bookmark.html.erb
@@ -1,10 +1,10 @@
 <div class="card mb-3">
   <div class="card-body">
-    <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id), data: { turbo: false } %></h4><br>
+    <h4 class="card-title"><%= link_to bookmark.post.title, post_path(bookmark.post.id), data: { turbo_frame: "_top" } %></h4><br>
     <p class="card-text"><%= simple_format(bookmark.post.description) %> </p>
       <p class="card-text text-end "><%= t('.user')%>:<%= bookmark.user.name %></p>
       <div class="d-flex justify-content-between">
-        <%= form_with url: bookmark_path(bookmark), method: :delete, class: "d-inline", data: { turbo: false } do %>
+        <%= form_with url: bookmark_path(bookmark), method: :delete, class: "d-inline", data: { turbo_frame: "_top" } do %>
           <button type="submit" class="btn btn-outline-danger">
             <i class="fa-solid fa-heart"></i> いいね解除
           </button>

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -5,9 +5,9 @@
     <%= render partial: 'bookmark', collection: @bookmarks %>
   </turbo-frame>
   <div class=" page container d-flex justify-content-center">
-  <%= link_to 'Previous', bookmarks_path(page: @previous_page), data: { turbo: false }, class: "mx-2" if @previous_page %>
+  <%= link_to 'Previous', bookmarks_path(page: @previous_page), data: { turbo_frame: "_top" }, class: "mx-2" if @previous_page %>
   <%= @page %>
-  <%= link_to 'Next', bookmarks_path(page: @next_page), data: { turbo: false }, class: "mx-2" if @next_page %>
+  <%= link_to 'Next', bookmarks_path(page: @next_page), data: { turbo_frame: "_top" }, class: "mx-2" if @next_page %>
   </div>
 <% else %>
   <div class="container d-flex justify-content-center align-items-center" style="height: 100vh;">

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,6 +1,6 @@
 <div class="card mb-3">
   <div class="card-body">
-    <h4 class="card-title"><%= link_to post.title, post_path(post), data: { turbo: false } %></h4><br>
+    <h4 class="card-title"><%= link_to post.title, post_path(post), data: { turbo_frame: "_top" } %></h4><br>
     <p class="card-text"><%= simple_format(post.description) %> </p>
     <p class="card-text text-end "><%= t('.user')%>:<%= post.user.name %>
     <p class="card-text text-end "><%= t('.post_day')%>:<%= post.created_at.strftime('%Y年%m月%d日') %></p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,9 +9,9 @@
     <%= render @posts %>
   </turbo-frame>
   <div class=" page container d-flex justify-content-center">
-  <%= link_to 'Previous', posts_path(page: @previous_page), data: { turbo: false }, class: "mx-2" if @previous_page %>
+  <%= link_to 'Previous', posts_path(page: @previous_page), data: { turbo_frame: "_top" }, class: "mx-2" if @previous_page %>
   <%= @page %>
-  <%= link_to 'Next', posts_path(page: @next_page), data: { turbo: false }, class: "mx-2" if @next_page %>
+  <%= link_to 'Next', posts_path(page: @next_page), data: { turbo_frame: "_top" }, class: "mx-2" if @next_page %>
 </div>
 <% else %>
   <div class="container d-flex justify-content-center align-items-center" style="height: 100vh;">


### PR DESCRIPTION
### 概要
現在、turbo-frame 内でリンクやフォームの turbo を無効化しているが、data: { turbo_frame: "_top" } を使用することで、ページ全体を更新することなく、URLを含めた部分的なページ更新を実現できるように修正しました。
```
data: { turbo_frame: "_top" }
```

---
### 修正内容

1. postsのページネーションのリンクと投稿詳細ページへのリンクをurlを含めた部分的なページ更新ができるように修正

2. bookmarksのページネーションのリンクと投稿詳細ページへのリンクといいね解除ボタンをurlを含めた部分的なページ更新ができるように修正

---